### PR TITLE
Handle characters above U+FFFF in GLOBAL_SENTENCE_BOUNDARY_REGEX

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -3,7 +3,7 @@ import GLOBAL_SENTENCE_TERMINATORS from './terminators.js'
 export default class Language {
   static GLOBAL_SENTENCE_BOUNDARY_REGEX = new RegExp(
     `[${GLOBAL_SENTENCE_TERMINATORS.join('')}]+`,
-    'g'
+    'gu'
   )
 
   static EXCLAMATION_WORDS = new Set(

--- a/test/en.test.js
+++ b/test/en.test.js
@@ -217,6 +217,16 @@ const tests = {
 
 }
 
+// Check for spurious matching of unpaired surrogate in RegExp character class. This can happen
+// because a sentence terminator above U+FFFF is represented as two Javascript characters,
+// and so putting it into a RegExp character class will match either surrogate separately.
+// For example, U+1BC9F (Duployan Punctuation Chinook Full Stop) is represented as
+// '\uD82F\uDC9F', but a character class [\uD82F\uDC9F] will match other characters such as
+// U+1BC00 (represented as '\uD82F\uDC00').
+// Test contributed by David Chan
+const lettersAboveFFFF = String.fromCodePoint(0x1BC00).repeat(10)
+tests[lettersAboveFFFF] = [lettersAboveFFFF]
+
 describe('English segment()', function () {
   for (const [text, expectedSentences] of Object.entries(tests)) {
     it(`correctly segments text: ${text}`, function () {


### PR DESCRIPTION
Regex has a `u` flag to handle them properly
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode

Add test contributed by David Chan

Fixes issue #2